### PR TITLE
add Close() and Wait() to the Usage page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ From Go:
 
 ```go
 m := librato.NewSimpleMetrics(user, token, source)
+defer m.Wait()
+defer m.Close()
 
 c := m.GetCounter("foo")
 c <- 47


### PR DESCRIPTION
Thanks for the client Richard!  A minor nit, but I wonder if you'd consider adding proper usage of SimpleMetrics.Close() and SimpleMetrics.Wait() to the usage page (since not using them in real life could result in a race condition) ?
