### PR TITLE
Added Warning around `source` containing spaces

### DIFF
--- a/collated.go
+++ b/collated.go
@@ -27,6 +27,10 @@ type CollatedMetrics struct {
 // goroutines used internally.
 func NewCollatedMetrics(user, token, source string,
 	collateMax int) Metrics {
+	if containAnySpaces(source) {
+		log.Println("Warning! Source cannot contain any spaces.")
+	}
+
 	m := &CollatedMetrics{
 		user, token, source,
 		collateMax,

--- a/collated.go
+++ b/collated.go
@@ -17,8 +17,10 @@ type CollatedMetrics struct {
 	collateMax                     int
 	quit, running                  chan bool
 	collateCounters, collateGauges chan map[string]interface{}
-	counters, gauges               map[string]chan int64
-	customCounters, customGauges   map[string]chan map[string]int64
+	counters                       map[string]chan int64
+	gauges                         map[string]chan float64
+	customCounters                 map[string]chan map[string]int64
+	customGauges                   map[string]chan map[string]float64
 	httpClient                     *http.Client
 }
 
@@ -37,9 +39,10 @@ func NewCollatedMetrics(user, token, source string,
 		make(chan bool), make(chan bool),
 		make(chan map[string]interface{}, collateMax),
 		make(chan map[string]interface{}, collateMax),
-		make(map[string]chan int64), make(map[string]chan int64),
+		make(map[string]chan int64),
+		make(map[string]chan float64),
 		make(map[string]chan map[string]int64),
-		make(map[string]chan map[string]int64),
+		make(map[string]chan map[string]float64),
 		&http.Client{Transport: http.DefaultTransport},
 	}
 
@@ -147,7 +150,7 @@ func (m *CollatedMetrics) GetCustomCounter(name string) chan map[string]int64 {
 }
 
 // Get (possibly by creating) a custom gauge channel by the given name.
-func (m *CollatedMetrics) GetCustomGauge(name string) chan map[string]int64 {
+func (m *CollatedMetrics) GetCustomGauge(name string) chan map[string]float64 {
 	ch, ok := m.customGauges[name]
 	if ok {
 		return ch
@@ -156,7 +159,7 @@ func (m *CollatedMetrics) GetCustomGauge(name string) chan map[string]int64 {
 }
 
 // Get (possibly by creating) a gauge channel by the given name.
-func (m *CollatedMetrics) GetGauge(name string) chan int64 {
+func (m *CollatedMetrics) GetGauge(name string) chan float64 {
 	ch, ok := m.gauges[name]
 	if ok {
 		return ch
@@ -181,16 +184,16 @@ func (m *CollatedMetrics) NewCustomCounter(name string) chan map[string]int64 {
 }
 
 // Create a custom gauge channel by the given name.
-func (m *CollatedMetrics) NewCustomGauge(name string) chan map[string]int64 {
-	ch := make(chan map[string]int64)
+func (m *CollatedMetrics) NewCustomGauge(name string) chan map[string]float64 {
+	ch := make(chan map[string]float64)
 	m.customGauges[name] = ch
 	go m.newMetric(name, ch, m.collateGauges)
 	return ch
 }
 
 // Create a gauge channel by the given name.
-func (m *CollatedMetrics) NewGauge(name string) chan int64 {
-	ch := make(chan int64)
+func (m *CollatedMetrics) NewGauge(name string) chan float64 {
+	ch := make(chan float64)
 	m.gauges[name] = ch
 	go m.newMetric(name, ch, m.collateGauges)
 	return ch

--- a/librato.go
+++ b/librato.go
@@ -3,6 +3,8 @@
 // <https://github.com/rcrowley/go-librato>
 package librato
 
+import "strings"
+
 type Metrics interface {
 	Close()
 	GetCounter(name string) chan int64
@@ -35,3 +37,17 @@ func handle(i interface{}, bodyMetric tmetric) bool {
 type tbody map[string]tibody
 type tibody []tmetric
 type tmetric map[string]interface{}
+
+// Check whether a string contains any spaces
+func containAnySpaces(str string) bool {
+	// Contains leading or trailing white space.
+	if strings.TrimSpace(str) != str {
+		return true
+	}
+	// Check if there are any spaces between words.
+	if strings.Fields(str)[0] != str {
+		return true
+	}
+
+	return false
+}

--- a/librato.go
+++ b/librato.go
@@ -9,12 +9,12 @@ type Metrics interface {
 	Close()
 	GetCounter(name string) chan int64
 	GetCustomCounter(name string) chan map[string]int64
-	GetCustomGauge(name string) chan map[string]int64
-	GetGauge(name string) chan int64
+	GetCustomGauge(name string) chan map[string]float64
+	GetGauge(name string) chan float64
 	NewCounter(name string) chan int64
 	NewCustomCounter(name string) chan map[string]int64
-	NewCustomGauge(name string) chan map[string]int64
-	NewGauge(name string) chan int64
+	NewCustomGauge(name string) chan map[string]float64
+	NewGauge(name string) chan float64
 	Wait()
 }
 

--- a/simple.go
+++ b/simple.go
@@ -31,6 +31,10 @@ type SimpleMetrics struct {
 // Create a new `SimpleMetrics` struct with the given credentials and source
 // tag.  Initialize all the channels, maps, and goroutines used internally.
 func NewSimpleMetrics(user, token, source string) Metrics {
+	if containAnySpaces(source) {
+		log.Println("Warning! Source cannot contain any spaces.")
+	}
+
 	m := &SimpleMetrics{
 		user, token, source,
 		make(chan bool), make(chan bool),

--- a/simple.go
+++ b/simple.go
@@ -21,11 +21,13 @@ var uaString = func() string {
 // metrics to the API, the source tag for these metrics, bookkeeping for
 // goroutines, and lookup tables for existing metric channels.
 type SimpleMetrics struct {
-	user, token, source          string
-	quit, running                chan bool
-	counters, gauges             map[string]chan int64
-	customCounters, customGauges map[string]chan map[string]int64
-	httpClient                   *http.Client
+	user, token, source string
+	quit, running       chan bool
+	counters            map[string]chan int64
+	gauges              map[string]chan float64
+	customCounters      map[string]chan map[string]int64
+	customGauges        map[string]chan map[string]float64
+	httpClient          *http.Client
 }
 
 // Create a new `SimpleMetrics` struct with the given credentials and source
@@ -38,9 +40,10 @@ func NewSimpleMetrics(user, token, source string) Metrics {
 	m := &SimpleMetrics{
 		user, token, source,
 		make(chan bool), make(chan bool),
-		make(map[string]chan int64), make(map[string]chan int64),
+		make(map[string]chan int64),
+		make(map[string]chan float64),
 		make(map[string]chan map[string]int64),
-		make(map[string]chan map[string]int64),
+		make(map[string]chan map[string]float64),
 		&http.Client{Transport: http.DefaultTransport},
 	}
 
@@ -110,7 +113,7 @@ func (m *SimpleMetrics) GetCustomCounter(name string) chan map[string]int64 {
 }
 
 // Get (possibly by creating) a custom gauge channel by the given name.
-func (m *SimpleMetrics) GetCustomGauge(name string) chan map[string]int64 {
+func (m *SimpleMetrics) GetCustomGauge(name string) chan map[string]float64 {
 	ch, ok := m.customGauges[name]
 	if ok {
 		return ch
@@ -119,7 +122,7 @@ func (m *SimpleMetrics) GetCustomGauge(name string) chan map[string]int64 {
 }
 
 // Get (possibly by creating) a gauge channel by the given name.
-func (m *SimpleMetrics) GetGauge(name string) chan int64 {
+func (m *SimpleMetrics) GetGauge(name string) chan float64 {
 	ch, ok := m.gauges[name]
 	if ok {
 		return ch
@@ -144,16 +147,16 @@ func (m *SimpleMetrics) NewCustomCounter(name string) chan map[string]int64 {
 }
 
 // Create a custom gauge channel by the given name.
-func (m *SimpleMetrics) NewCustomGauge(name string) chan map[string]int64 {
-	ch := make(chan map[string]int64)
+func (m *SimpleMetrics) NewCustomGauge(name string) chan map[string]float64 {
+	ch := make(chan map[string]float64)
 	m.customGauges[name] = ch
 	go m.newMetric("gauges", name, ch)
 	return ch
 }
 
 // Create a gauge channel by the given name.
-func (m *SimpleMetrics) NewGauge(name string) chan int64 {
-	ch := make(chan int64)
+func (m *SimpleMetrics) NewGauge(name string) chan float64 {
+	ch := make(chan float64)
 	m.gauges[name] = ch
 	go m.newMetric("gauges", name, ch)
 	return ch


### PR DESCRIPTION
If source contains any spaces, Librato/go-librato won't tell you that this fails, it just fails silently. Added a warning when creating a CollatedMetric or SimpleMetric if your source arg contains any spaces.
